### PR TITLE
Fix: GitHub Pages deployment for React webapp

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -47,4 +47,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          publish_dir: ./build

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>
 


### PR DESCRIPTION
Update `index.html` and GitHub Actions workflow to correctly deploy the React webapp to GitHub Pages.

* Change the `src` attribute of the `<script>` tag in `index.html` to `./src/main.tsx`.
* Change the `publish_dir` value in the `Deploy to GitHub Pages` step of `.github/workflows/static.yml` to `./build`.

